### PR TITLE
fix numpy warning

### DIFF
--- a/src/exospy/exospy.py
+++ b/src/exospy/exospy.py
@@ -851,19 +851,16 @@ def generateObservationMatrix(los,pos,exosgrid):
 #-------------------------------------------------------------------------------
 def generate3DHmodel(model,exosgrid):
   H = np.zeros((int(exosgrid.numvoxels),1))
-  theta = np.array([[0.0]])
-  rad = np.array([[0.0]])
-  phi = np.array([[0.0]])
 
   for t_id in range(int(exosgrid.numT)):
-    theta[0,0] = exosgrid.tvals[t_id]+exosgrid.tstep/2
-    theta[0,0] = theta[0,0]*np.pi/180
+    theta = exosgrid.tvals[t_id]+exosgrid.tstep/2
+    theta = theta*np.pi/180
     for p_id in range(int(exosgrid.numP)):
-      phi[0,0] = exosgrid.pvals[p_id]+exosgrid.pstep/2
-      phi[0,0] = phi[0,0]*np.pi/180
+      phi = exosgrid.pvals[p_id]+exosgrid.pstep/2
+      phi = phi*np.pi/180
       for r_id in range(int(exosgrid.numR)):
-        rad[0,0] = exosgrid.rvals[r_id]+exosgrid.rstep/2
-        H[int(r_id+p_id*exosgrid.numR+t_id*exosgrid.numR*exosgrid.numP),0] = get_density(model,rad,theta,phi)
+        rad = exosgrid.rvals[r_id]+exosgrid.rstep/2
+        H[int(r_id+p_id*exosgrid.numR+t_id*exosgrid.numR*exosgrid.numP),0] = get_density(model,rad,theta,phi)[0]
         #print(rad,theta,phi)
 
   return H


### PR DESCRIPTION
Recent versions of numpy spit out a warning because `generate3DHModel` assigns a 1-element array returned by `get_density` to an index in the `H` array.

```
  /home/evan/resources/exospy/src/exospy/exospy.py:867: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    H[int(r_id+p_id*exosgrid.numR+t_id*exosgrid.numR*exosgrid.numP),0] = get_density(model,rad,theta,phi)
```
